### PR TITLE
Parity is not hosted by crates.io (#3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
     export RUST_BACKTRACE=1 &&
     cargo fmt -- --write-mode=diff &&
     (test "$TRAVIS_RUST_VERSION" == nightly || cargo build) &&
-    (test "$TRAVIS_RUST_VERSION" != nightly || cargo build --features "clippy") &&
+    (test "$TRAVIS_RUST_VERSION" != nightly || cargo build --features "dev") &&
     cargo test &&
     cargo doc --no-deps
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "0.9"
 serde_derive = "0.9"
 # optional dependencies
 reqwest = { version = "0.4", optional = true }
-clippy = {version = "*", optional = true}
+clippy = {version = "0.0.*", optional = true}
 
 [dev-dependencies]
 

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ First public release.
 We recommend to use parity as ethereum classic node:
 
 ----
-$ cargo install parity
+$ cargo install --git https://github.com/ethcore/parity.git --branch beta --force parity
 ----
 
 How to run parity locally in development mode (v1.5+) on port '8545' (by default):
@@ -67,7 +67,7 @@ $ parity --chain dev --no-discovery --no-ui --no-ipc --no-dapps --rpccorsdomain 
 == Installation
 
 ----
-$ cargo install emerald-cli
+$ cargo install emerald-cli -f
 ----
 
 === Usage

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ struct JsonData<'a> {
     id: usize,
 }
 
-const NODE_URL: &str = "http://127.0.0.1:8546";
+static NODE_URL: &'static str = "http://127.0.0.1:8546";
 
 static NONE: Params = Params::None;
 
@@ -117,7 +117,7 @@ fn request<'a>(method: Method<'a>) -> BoxFuture<Value, Error> {
 }
 
 fn method(method: &'static str) -> JsonData {
-    method_params(method, &NONE as &'static Params)
+    method_params(method, &NONE)
 }
 
 fn method_params<'a>(method: &'static str, params: &'a Params) -> JsonData<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,9 @@ struct JsonData<'a> {
     id: usize,
 }
 
-const NODE_URL: &'static str = "http://127.0.0.1:8546";
+const NODE_URL: &str = "http://127.0.0.1:8546";
 
-const NONE: &'static Params = &Params::None;
+static NONE: Params = Params::None;
 
 lazy_static! {
     static ref REQ_ID: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(1));
@@ -117,7 +117,7 @@ fn request<'a>(method: Method<'a>) -> BoxFuture<Value, Error> {
 }
 
 fn method(method: &'static str) -> JsonData {
-    method_params(method, NONE)
+    method_params(method, &NONE as &'static Params)
 }
 
 fn method_params<'a>(method: &'static str, params: &'a Params) -> JsonData<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 //! Ethereum classic web3 like connector written in Rust.
 
+#![deny(warnings)]
 #![warn(missing_docs)]
 
 #![cfg_attr(feature = "dev", feature(plugin))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,11 +86,11 @@ fn main() {
 fn start(addr: &SocketAddr) {
     let mut io = IoHandler::default();
 
-    io.add_async_method("web3_clientVersion", |_| request(Method::ClientVersion));
-    io.add_async_method("eth_syncing", |_| request(Method::EthSyncing));
-    io.add_async_method("eth_blockNumber", |_| request(Method::EthBlockNumber));
-    io.add_async_method("eth_accounts", |_| request(Method::EthAccounts));
-    io.add_async_method("eth_getBalance", |p| request(Method::EthGetBalance(&p)));
+    io.add_async_method("web3_clientVersion", |_| request(&Method::ClientVersion));
+    io.add_async_method("eth_syncing", |_| request(&Method::EthSyncing));
+    io.add_async_method("eth_blockNumber", |_| request(&Method::EthBlockNumber));
+    io.add_async_method("eth_accounts", |_| request(&Method::EthAccounts));
+    io.add_async_method("eth_getBalance", |p| request(&Method::EthGetBalance(&p)));
 
     let server = ServerBuilder::new(io)
         .cors(DomainsValidation::AllowOnly(vec![cors::AccessControlAllowOrigin::Any,
@@ -105,11 +105,11 @@ fn start(addr: &SocketAddr) {
     server.wait().expect("Unable to start server");
 }
 
-fn request<'a>(method: Method<'a>) -> BoxFuture<Value, Error> {
+fn request(method: &Method) -> BoxFuture<Value, Error> {
     let client = reqwest::Client::new().expect("Error during create a client");
 
     let mut res = client.post(NODE_URL)
-        .json(&method)
+        .json(method)
         .send()
         .expect("Unable to get response object");
 


### PR DESCRIPTION
Install parity directly from github repository.