### PR TITLE
Problem: users don't know what OS dependencies are needed

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,12 @@ First public release.
 
 === Prerequisites
 
+Ensure you have these dependencies installed:
+
+----
+openssl gcc pkgconfig libudev
+----
+
 We recommend to use parity as ethereum classic node:
 
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -72,8 +72,14 @@ $ parity --chain dev --no-discovery --no-ui --no-ipc --no-dapps --rpccorsdomain 
 
 == Installation
 
+Ensure you have these dependencies installed:
+
 ----
-$ cargo install emerald-cli
+openssl gcc pkgconfig
+----
+
+----
+$ cargo install --git https://github.com/ethereumproject/emerald-rs emerald-rs
 ----
 
 === Usage


### PR DESCRIPTION
Solution: add "openssl gcc pkgconfig libudev" to the readme