### PR TITLE
Missed Keystore creation from generated data

### DIFF
--- a/src/keystore/error.rs
+++ b/src/keystore/error.rs
@@ -1,5 +1,6 @@
 //! # Keystore files (UTC / JSON) module errors
 
+use super::core;
 use std::{error, fmt};
 
 /// Keystore file errors
@@ -13,6 +14,8 @@ pub enum Error {
     UnsupportedPrf(String),
     /// `keccak256_mac` field validation failed
     FailedMacValidation,
+    /// Invalid format of `PrivateKey`
+    InvalidPrivateKey,
 }
 
 impl fmt::Display for Error {
@@ -26,6 +29,7 @@ impl fmt::Display for Error {
                 write!(f, "Unsupported pseudo-random function: {}", str)
             }
             Error::FailedMacValidation => write!(f, "Message authentication code failed"),
+            Error::InvalidPrivateKey => write!(f, "Invalid format of private key"),
         }
     }
 }
@@ -39,5 +43,11 @@ impl error::Error for Error {
         match *self {
             _ => None,
         }
+    }
+}
+
+impl From<core::Error> for Error {
+    fn from(_: core::Error) -> Self {
+        Error::InvalidPrivateKey
     }
 }

--- a/src/keystore/serialize/address.rs
+++ b/src/keystore/serialize/address.rs
@@ -129,17 +129,23 @@ mod tests {
     }
 
     #[test]
-    fn should_extract_address() {
+    fn should_extract_address_single_quoted() {
         assert_eq!(try_extract_address(r#"address: '008aeeda4d805471df9b2a5b0f38a0c3bcba786b',"#),
                    Some("0x008aeeda4d805471df9b2a5b0f38a0c3bcba786b"
                             .parse::<Address>()
                             .unwrap()));
+    }
 
+    #[test]
+    fn should_extract_address_double_quoted() {
         assert_eq!(try_extract_address(r#""address": "0047201aed0b69875b24b614dda0270bcd9f11cc","#),
-        Some("0x0047201aed0b69875b24b614dda0270bcd9f11cc"
-            .parse::<Address>()
-            .unwrap()));
+            Some("0x0047201aed0b69875b24b614dda0270bcd9f11cc"
+                .parse::<Address>()
+                .unwrap()));
+    }
 
+    #[test]
+    fn should_extract_address_with_optional_fields() {
         assert_eq!(try_extract_address(r#"  },
                      "address": "3f4e0668c20e100d7c2a27d4b177ac65b2875d26",
                      "name": "",

--- a/tests/keystore_test.rs
+++ b/tests/keystore_test.rs
@@ -144,8 +144,7 @@ fn should_decode_keyfile_with_address() {
 #[test]
 fn should_flush_to_file() {
     let pk = PrivateKey::gen();
-    let addr = pk.to_address().unwrap();
-    let kf = KeyFile::create(pk, "1234567890", Some(addr));
+    let kf = KeyFile::create(Some(pk), "1234567890", true).unwrap();
 
     assert!(kf.flush(temp_dir().as_path()).is_ok());
 }


### PR DESCRIPTION
No option for creation of keystore file with auto-generated value (private key & address).
Implemented