### PR TITLE
Lack of `KeyFile` random source customizations

### DIFF
--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -90,9 +90,9 @@ impl From<[u8; 64]> for Signature {
     }
 }
 
-impl From<Signature> for (u8, [u8; 32], [u8; 32]) {
-    fn from(s: Signature) -> Self {
-        (s.v, s.r, s.s)
+impl Into<(u8, [u8; 32], [u8; 32])> for Signature {
+    fn into(self) -> (u8, [u8; 32], [u8; 32]) {
+        (self.v, self.r, self.s)
     }
 }
 

--- a/src/keystore/kdf.rs
+++ b/src/keystore/kdf.rs
@@ -27,7 +27,7 @@ pub enum Kdf {
 
     /// Scrypt (by default, specified in (RPC 7914)[https://tools.ietf.org/html/rfc7914])
     Scrypt {
-        /// Number of iterations (`4096` by default)
+        /// Number of iterations (`19201` by default)
         n: u32,
 
         /// Block size for the underlying hash (`8` by default)
@@ -62,7 +62,7 @@ impl Kdf {
 impl Default for Kdf {
     fn default() -> Self {
         Kdf::Scrypt {
-            n: 4096,
+            n: 19201,
             r: 8,
             p: 1,
         }

--- a/src/keystore/serialize/byte_array.rs
+++ b/src/keystore/serialize/byte_array.rs
@@ -14,15 +14,15 @@ macro_rules! byte_array_struct {
             }
         }
 
-        impl From<$name> for [u8; $num] {
-            fn from(arr: $name) -> Self {
-                arr.0
-            }
-        }
-
         impl From<[u8; $num]> for $name {
             fn from(bytes: [u8; $num]) -> Self {
                 $name(bytes)
+            }
+        }
+
+        impl Into<[u8; $num]> for $name {
+            fn into(self) -> [u8; $num] {
+                self.0
             }
         }
 

--- a/src/keystore/serialize/error.rs
+++ b/src/keystore/serialize/error.rs
@@ -39,9 +39,7 @@ impl From<json::DecoderError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::UnsupportedVersion(ver) => {
-                write!(f, "Unsupported keystore file version: {}", ver)
-            }
+            Error::UnsupportedVersion(v) => write!(f, "Unsupported keystore file version: {}", v),
             Error::IO(ref err) => write!(f, "Keystore file IO error: {}", err),
             Error::InvalidDecoding(ref err) => write!(f, "Invalid keystore file decoding: {}", err),
             Error::InvalidEncoding(ref err) => write!(f, "Invalid keystore file encoding: {}", err),

--- a/src/keystore/serialize/mod.rs
+++ b/src/keystore/serialize/mod.rs
@@ -49,7 +49,7 @@ impl Decodable for KeyFile {
             return Err(d.error(&Error::UnsupportedVersion(ser.version).to_string()));
         }
 
-        Ok(KeyFile::from(ser))
+        Ok(ser.into())
     }
 }
 
@@ -79,12 +79,12 @@ impl From<KeyFile> for SerializableKeyFile {
     }
 }
 
-impl From<SerializableKeyFile> for KeyFile {
-    fn from(ser: SerializableKeyFile) -> KeyFile {
+impl Into<KeyFile> for SerializableKeyFile {
+    fn into(self) -> KeyFile {
         KeyFile {
-            uuid: ser.id,
-            address: ser.address,
-            ..KeyFile::from(ser.crypto)
+            uuid: self.id,
+            address: self.address,
+            ..KeyFile::from(self.crypto)
         }
     }
 }

--- a/src/rpc/error.rs
+++ b/src/rpc/error.rs
@@ -17,8 +17,8 @@ impl From<reqwest::Error> for Error {
     }
 }
 
-impl From<Error> for jsonrpc_core::Error {
-    fn from(_err: Error) -> Self {
+impl Into<jsonrpc_core::Error> for Error {
+    fn into(self) -> jsonrpc_core::Error {
         jsonrpc_core::Error::internal_error()
     }
 }

--- a/src/rpc/http.rs
+++ b/src/rpc/http.rs
@@ -26,7 +26,7 @@ impl AsyncWrapper {
             Ok(res) => ::futures::finished(res).boxed(),
             Err(err) => {
                 error!("HTTP POST request error: {}", err);
-                ::futures::failed(jsonrpc_core::Error::from(err)).boxed()
+                ::futures::failed(err.into()).boxed()
             }
         }
     }


### PR DESCRIPTION
1. Change `rand::thread_rng()` for `Uuid::new_v4()` to `OsRng::new()`.
2. Impl. `rand::Rand` trait for `KeyFile`.