### PR TITLE
Utility methods spread accross source code

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -13,7 +13,7 @@ static CHARS: &'static [u8] = b"0123456789abcdef";
 
 /// Convert `self` into hex string
 pub trait ToHex {
-    ///
+    /// converts to hex
     fn to_hex(&self) -> String;
 }
 
@@ -37,6 +37,11 @@ impl ToHex for u64 {
 }
 
 /// Convert byte array into `u64`
+///
+/// # Arguments
+///
+/// * `v` - array to be converted
+///
 pub fn to_u64(v: &[u8]) -> u64 {
     let data = align_bytes(v, 8);
     let mut buf = Cursor::new(&data);
@@ -45,6 +50,11 @@ pub fn to_u64(v: &[u8]) -> u64 {
 }
 
 /// Trix hex prefix `0x`
+///
+/// # Arguments
+///
+/// * `val` - string to be trimmed
+///
 pub fn trim_hex(val: &str) -> &str {
     if !val.starts_with("0x") {
         return val;
@@ -55,6 +65,11 @@ pub fn trim_hex(val: &str) -> &str {
 }
 
 /// Convert a slice into array
+///
+/// # Arguments
+///
+/// * `slice` - slice to be converted
+///
 pub fn to_arr<A, T>(slice: &[T]) -> A
     where A: AsMut<[T]> + Default,
           T: Clone
@@ -65,6 +80,12 @@ pub fn to_arr<A, T>(slice: &[T]) -> A
 }
 
 /// Padding high bytes with `O` to fit `len` bytes
+///
+/// # Arguments
+///
+/// * `data` - data to be aligned
+/// * `len` - length of required array
+///
 pub fn align_bytes(data: &[u8], len: usize) -> Vec<u8> {
     let mut v = vec![0u8; len - data.len()];
     v.extend_from_slice(data);
@@ -72,6 +93,11 @@ pub fn align_bytes(data: &[u8], len: usize) -> Vec<u8> {
 }
 
 /// Trim all high zero bytes
+///
+/// # Arguments
+///
+/// * `data` - value to be trimmed
+///
 pub fn trim_bytes(data: &[u8]) -> &[u8] {
     let mut n = 0;
     for b in data {
@@ -83,16 +109,27 @@ pub fn trim_bytes(data: &[u8]) -> &[u8] {
     &data[n..data.len()]
 }
 
-/// Counts bytes required to encode value into `RLP`
-fn rlp_bytes_count(x: usize) -> u8 {
+/// Counts bytes required to hold `x` value
+///
+/// # Arguments
+///
+/// * `x` - value to find size
+///
+fn bytes_count(x: usize) -> u8 {
     match x {
-        _ if x > 0xff => 1 + rlp_bytes_count(x >> 8),
+        _ if x > 0xff => 1 + bytes_count(x >> 8),
         _ if x > 0 => 1,
         _ => 0,
     }
 }
 
 /// Converts `unsigned` value to byte array
+///
+/// # Arguments
+///
+/// * `x` - a value to be converted into byte vector
+/// * `len` - size of value
+///
 fn to_bytes(x: u64, len: u8) -> Vec<u8> {
     let mut buf = vec![];
     match len {
@@ -111,7 +148,6 @@ pub use self::tests::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustc_serialize::hex::FromHex;
     use tests::*;
 
     pub fn to_16bytes(hex: &str) -> [u8; 16] {
@@ -200,16 +236,16 @@ mod tests {
 
     #[test]
     fn should_count_bytes_for_rlp() {
-        assert_eq!(rlp_bytes_count(0x00), 0);
-        assert_eq!(rlp_bytes_count(0x01), 1);
-        assert_eq!(rlp_bytes_count(0xff), 1);
-        assert_eq!(rlp_bytes_count(0xff01), 2);
-        assert_eq!(rlp_bytes_count(0xffff01), 3);
+        assert_eq!(bytes_count(0x00), 0);
+        assert_eq!(bytes_count(0x01), 1);
+        assert_eq!(bytes_count(0xff), 1);
+        assert_eq!(bytes_count(0xff01), 2);
+        assert_eq!(bytes_count(0xffff01), 3);
 
     }
 
     #[test]
-    fn u8_to_bytes() {
+    fn should_convert_u8_to_bytes() {
         assert_eq!([1], to_bytes(1, 1).as_slice());
         assert_eq!([2], to_bytes(2, 1).as_slice());
         assert_eq!([127], to_bytes(127, 1).as_slice());
@@ -218,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn u16_to_bytes() {
+    fn should_convert_u16_to_bytes() {
         assert_eq!([0, 1], to_bytes(1, 2).as_slice());
         assert_eq!([0, 2], to_bytes(2, 2).as_slice());
         assert_eq!([0, 255], to_bytes(255, 2).as_slice());
@@ -228,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn u32_to_bytes() {
+    fn should_convert_u32_to_bytes() {
         assert_eq!([0, 0, 0, 1], to_bytes(1, 4).as_slice());
         assert_eq!([0x12, 0x34, 0x56, 0x78], to_bytes(0x12345678, 4).as_slice());
         assert_eq!([0xff, 0x0, 0x0, 0x0], to_bytes(0xff000000, 4).as_slice());
@@ -236,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn u64_to_bytes() {
+    fn should_convert_u64_to_bytes() {
         assert_eq!([0, 0, 0, 0, 0, 0, 0, 1], to_bytes(1, 8).as_slice());
         assert_eq!([0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef],
                    to_bytes(0x1234567890abcdef, 8).as_slice());

--- a/src/util/rlp.rs
+++ b/src/util/rlp.rs
@@ -3,7 +3,7 @@
 //!
 //! See [RLP spec](https://github.com/ethereumproject/wiki/wiki/RLP)
 
-use super::{rlp_bytes_count, to_bytes, trim_bytes};
+use super::{bytes_count, to_bytes, trim_bytes};
 
 /// The `WriteRLP` trait is used to specify functionality of serializing data to RLP bytes
 pub trait WriteRLP {
@@ -140,7 +140,7 @@ impl WriteRLP for [u8] {
             // followed by the length of the string, followed by the string. For example, a
             // length-1024 string would be encoded as \xb9\x04\x00 followed by the string. The
             // range of the first byte is thus [0xb8, 0xbf].
-            let len_bytes = rlp_bytes_count(len);
+            let len_bytes = bytes_count(len);
             buf.push(0xb7 + len_bytes);
             buf.extend_from_slice(&to_bytes(len as u64, len_bytes));
             buf.extend_from_slice(self);
@@ -163,7 +163,7 @@ impl WriteRLP for RLPList {
             // payload in binary form, followed by the length of the payload, followed by the
             // concatenation of the RLP encodings of the items. The range of the first byte is
             // thus [0xf8, 0xff].
-            let len_bytes = rlp_bytes_count(len);
+            let len_bytes = bytes_count(len);
             buf.push(0xf7 + len_bytes);
             buf.extend_from_slice(&to_bytes(len as u64, len_bytes));
         }


### PR DESCRIPTION
Utility methods refactored using `byteorder` crate, added unit tests