### PR TITLE
New wallet generation not worked.

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -354,19 +354,23 @@ pub fn start(addr: &SocketAddr,
                                    .boxed();
                 }
 
-                let name = p.get("name").map(|n| {
-                    if n.as_str().is_some() {
-                        return Some(n.as_str().unwrap().to_string());
-                    }
-                    None
-                }).unwrap_or(None);
+                let name = p.get("name")
+                    .map(|n| {
+                             if n.as_str().is_some() {
+                                 return Some(n.as_str().unwrap().to_string());
+                             }
+                             None
+                         })
+                    .unwrap_or(None);
 
-                let description = p.get("description").map(|d| {
-                    if d.as_str().is_some() {
-                        return Some(d.as_str().unwrap().to_string());
-                    }
-                    None
-                }).unwrap_or(None);
+                let description = p.get("description")
+                    .map(|d| {
+                             if d.as_str().is_some() {
+                                 return Some(d.as_str().unwrap().to_string());
+                             }
+                             None
+                         })
+                    .unwrap_or(None);
 
                 match KeyFile::new(&p_str.unwrap(), &sec, name, description) {
                     Ok(kf) => {

--- a/tests/keystore_test.rs
+++ b/tests/keystore_test.rs
@@ -144,17 +144,17 @@ fn should_decode_keyfile_with_address() {
 #[test]
 fn should_use_security_level() {
     let sec = KdfDepthLevel::Normal;
-    let kf = KeyFile::new("1234567890", &sec).unwrap();
+    let kf = KeyFile::new("1234567890", &sec, None, None).unwrap();
     assert_eq!(kf.kdf, Kdf::from(sec));
 
     let sec = KdfDepthLevel::High;
-    let kf = KeyFile::new("1234567890", &sec).unwrap();
+    let kf = KeyFile::new("1234567890", &sec, Some("s".to_string()), None).unwrap();
     assert_eq!(kf.kdf, Kdf::from(sec));
 }
 
 #[test]
 fn should_flush_to_file() {
-    let kf = KeyFile::new("1234567890", &KdfDepthLevel::Normal).unwrap();
+    let kf = KeyFile::new("1234567890", &KdfDepthLevel::Normal, None, None).unwrap();
 
     assert!(kf.flush(temp_dir().as_path()).is_ok());
 }


### PR DESCRIPTION
Invalid handling of rpccall parameters (data was parsed as string, not map object)
Added handling for `name` & `description` fields