### PR TITLE
README - Adjusted for minimum cargo/rustc requirement

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,13 +53,17 @@ Ensure you have these dependencies installed:
 openssl gcc pkgconfig
 ----
 
+Also ensure that your installation of cargo (version 0.18) and rustc (version 1.17) is up to date.
+
+If your distribution or operating system does not have recent cargo and rustc binaries you can install them from: http://doc.crates.io/
+
 ----
 $ git clone https://github.com/ethereumproject/emerald-rs
 ----
 
 === Usage
 
-How to run emerald connector (on port '1920' by default) on top of ethereum classic node (we recommend link:https://github.com/ethereumproject/go-ethereum[Geth]):
+How to run emerald connector (on port '1920' by default) on top of ethereum classic node. We recommend: https://github.com/ethereumproject/go-ethereum[Geth]:
 
 ----
 $ RUST_LOG=emerald,rpc cargo run


### PR DESCRIPTION
There appears to be a minimum cargo/rustc requirement. Adjusted the README to clarify this.

For reference:

I'm on Ubuntu 16.0.4.2 LTS. When using the default packages of `cargo 0.8.0` and `rustc 1.7.0`, attempting to do `cargo run --verbose` gives the errors I pasted below.

Also it's a bit non-deterministic. If I git reset --hard and run the below commands again I'll sometimes get an issue with the `serde_json` package instead of the `crono` package.

Then to see if old versions of `cargo` (such as those that ship with Ubuntu) were the issue I ran the scripts located at http://doc.crates.io/ to get `cargo 0.18` and `rustc 1.17` installed. This fixed the error and everything compiled fine.

I'm thinking the README could do with either advice to use http://doc.crates.io/ or at least specifying the minimum versions required to get this running.

Error message below, can ignore, just including for the sake of other people's Googling.

```
me@me-VirtualBox:~/projects/emerald-rs$ export RUST_LOG="emerald, rpc"
me@me-VirtualBox:~/projects/emerald-rs$ cargo run --verbose
unused manifest key: badges.appveyor.repository
unused manifest key: badges.travis-ci.repository
unused manifest key: package.categories
    Updating git repository `https://github.com/paritytech/jsonrpc.git`
Unable to update https://github.com/paritytech/jsonrpc.git

Caused by:
  failed to parse manifest at `/home/me/.cargo/git/checkouts/jsonrpc-4db3b51a7e54a138/master/ipc/Cargo.toml`

Caused by:
  could not parse input as TOML
/home/me/.cargo/git/checkouts/jsonrpc-4db3b51a7e54a138/master/ipc/Cargo.toml:23:9 expected a key but found an empty string
/home/me/.cargo/git/checkouts/jsonrpc-4db3b51a7e54a138/master/ipc/Cargo.toml:23:9-23:10 expected `.`, but found `'`

me@me-VirtualBox:~/projects/emerald-rs$ cargo run --verbose
unused manifest key: badges.appveyor.repository
unused manifest key: badges.travis-ci.repository
unused manifest key: package.categories
    Updating registry `https://github.com/rust-lang/crates.io-index`
failed to parse registry's information for: chrono

Caused by:
  the given version requirement is invalid
```