### PR TITLE
Problem: no easy way to setup project dependencies for nix users

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,35 @@
+{ pkgs ? (
+  let
+    nixpkgs = import <nixpkgs>;
+    pkgs_ = (nixpkgs {});
+    rustOverlay = (pkgs_.fetchFromGitHub {
+      owner = "mozilla";
+      repo = "nixpkgs-mozilla";
+      rev = "e2a920faec5a9ebd6ff34abf072aacb4e0ed6f70";
+      sha256 = "1lq7zg388y4wrbl165wraji9dmlb8rkjaiam9bq28n3ynsp4b6fz";
+    });
+  in (nixpkgs {
+    overlays = [
+      (import (builtins.toPath "${rustOverlay}/rust-overlay.nix"))
+      (self: super: {
+        rust = {
+          rustc = super.rustChannels.stable.rust;
+          cargo = super.rustChannels.stable.cargo;
+        };
+        rustPlatform = super.recurseIntoAttrs (super.makeRustPlatform {
+          rustc = super.rustChannels.stable.rust;
+          cargo = super.rustChannels.stable.cargo;
+        });
+      })
+    ];
+  }))
+}:
+
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "emerald-env";
+  buildInputs = [
+    rustc cargo openssl pkgconfig
+  ];
+}


### PR DESCRIPTION
Solution: add a shell.nix which'll pull down all the needed
dependencies such as openssl, rust, cargo pkgconfig etc