### PR TITLE
Impossible usage of `rust-scrypt` on Windows OS due to mmap call

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,11 +52,11 @@ environment:
   # Nightly 64-bit MSVC
     - channel: nightly
       target: x86_64-pc-windows-msvc
-      cargoflags: --features "dev"
+      cargoflags: --all --features "dev"
   # Nightly 32-bit MSVC
     - channel: nightly
       target: i686-pc-windows-msvc
-      cargoflags: --features "dev"
+      cargoflags: --all --features "dev"
 
 ### GNU Toolchains ###
 
@@ -75,11 +75,11 @@ environment:
   # Nightly 64-bit GNU
     - channel: nightly
       target: x86_64-pc-windows-gnu
-      cargoflags: --features "dev"
+      cargoflags: --all  --features "dev"
   # Nightly 32-bit GNU
     - channel: nightly
       target: i686-pc-windows-gnu
-      cargoflags: --features "dev"
+      cargoflags: --all --features "dev"
 
 ### Allowed failures ###
 

--- a/emerald-core/Cargo.toml
+++ b/emerald-core/Cargo.toml
@@ -43,8 +43,10 @@ hyper = { version = "0.11", optional = true }
 reqwest = { version = "0.6", optional = true }
 clippy = {version = "0.0", optional = true}
 chrono = "0.4"
-rust-scrypt = "0.1"
 csv = "0.15"
+
+[target.'cfg(unix)'.dependencies]
+rust-scrypt = "0.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/emerald-core/src/keystore/kdf.rs
+++ b/emerald-core/src/keystore/kdf.rs
@@ -6,7 +6,7 @@ use crypto::pbkdf2::pbkdf2;
 
 //TODO: solve `mmap` call on windows for `rust-scrypt`
 #[cfg(target_os = "windows")]
-use crypto::scrypt::{ScryptParams as SParams, scrypt};
+use crypto::scrypt::{ScryptParams, scrypt};
 
 #[cfg(all(unix))]
 use rust_scrypt::{ScryptParams, scrypt};


### PR DESCRIPTION
`mmap` call used in Scrypt C library is only Unix specific.
Added conditional dependency for using `rust-crypto` on Windows
Related to #138