### PR TITLE
Lack of informative error handling

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -125,4 +125,4 @@ cache:
 # environment variable.
 test_script:
   - set RUST_BACKTRACE=1
-  - cargo test --verbose %cargoflags%
+  - cargo test --all --verbose %cargoflags%

--- a/emerald-core/src/rpc/mod.rs
+++ b/emerald-core/src/rpc/mod.rs
@@ -11,7 +11,7 @@ use super::contract::Contracts;
 use super::core::{self, Address, Transaction};
 use super::keystore::{KdfDepthLevel, KeyFile, list_accounts};
 use super::storage::{ChainStorage, Storages, default_keystore_path};
-use super::util::{ToHex, align_bytes, to_arr, to_u64, trim_hex};
+use super::util::{ToHex, align_bytes, to_arr, to_even, to_u64, trim_hex};
 use futures;
 use jsonrpc_core::{Error as JsonRpcError, ErrorCode, IoHandler, Params};
 use jsonrpc_core::futures::Future;

--- a/emerald-core/src/rpc/serialize.rs
+++ b/emerald-core/src/rpc/serialize.rs
@@ -1,6 +1,6 @@
 //! # Serialize JSON RPC parameters
 
-use super::{Error, ToHex, align_bytes, to_arr, to_even, to_u64, trim_hex};
+use super::{Error, ToHex, align_bytes, to_arr, to_even_str, to_u64, trim_hex};
 use super::core::{Address, PrivateKey, Transaction};
 use jsonrpc_core::{Params, Value as JValue};
 use rustc_serialize::hex::FromHex;
@@ -27,9 +27,7 @@ impl RPCTransaction {
         let gas_limit = trim_hex(self.gas.as_str()).from_hex()?;
         let gas_price = gp_str.from_hex()?;
         let value = v_str.from_hex()?;
-
-        let v = trim_hex(self.nonce.as_str()).from_hex()?;
-        let nonce = to_even(&v);
+        let nonce = to_even_str(trim_hex(self.nonce.as_str())).from_hex()?;
 
         Ok(Transaction {
             nonce: to_u64(&nonce),

--- a/emerald-core/src/rpc/serialize.rs
+++ b/emerald-core/src/rpc/serialize.rs
@@ -1,6 +1,6 @@
 //! # Serialize JSON RPC parameters
 
-use super::{Error, ToHex, align_bytes, to_arr, to_u64, trim_hex};
+use super::{Error, ToHex, align_bytes, to_arr, to_even, to_u64, trim_hex};
 use super::core::{Address, PrivateKey, Transaction};
 use jsonrpc_core::{Params, Value as JValue};
 use rustc_serialize::hex::FromHex;
@@ -31,7 +31,9 @@ impl RPCTransaction {
         let gas_limit = trim_hex(self.gas.as_str()).from_hex()?;
         let gas_price = gp_str.from_hex()?;
         let value = v_str.from_hex()?;
-        let nonce = trim_hex(self.nonce.as_str()).from_hex()?;
+
+        let v = trim_hex(self.nonce.as_str()).from_hex()?;
+        let nonce = to_even(&v);
 
         Ok(Transaction {
             nonce: to_u64(&nonce),

--- a/emerald-core/src/util/mod.rs
+++ b/emerald-core/src/util/mod.rs
@@ -64,6 +64,8 @@ pub fn trim_hex(val: &str) -> &str {
     s
 }
 
+
+
 /// Convert a slice into array
 ///
 /// # Arguments
@@ -88,9 +90,24 @@ where
 /// * `len` - length of required array
 ///
 pub fn align_bytes(data: &[u8], len: usize) -> Vec<u8> {
+    if data.len() >= len {
+        return data.to_vec();
+    }
+
     let mut v = vec![0u8; len - data.len()];
     v.extend_from_slice(data);
     v
+}
+
+/// Padding high bytes with `O` to get even length
+///
+/// # Arguments
+///
+/// * `data` - data to be aligned
+///
+pub fn to_even(data: &[u8]) -> Vec<u8> {
+    let len = data.len();
+    align_bytes(data, len + len % 2)
 }
 
 /// Trim all high zero bytes
@@ -278,6 +295,30 @@ mod tests {
     fn should_align_full_bytes() {
         assert_eq!(
             align_bytes(&[1, 2, 3, 4, 5, 6, 7, 8], 8),
+            vec![1, 2, 3, 4, 5, 6, 7, 8]
+        );
+    }
+
+    #[test]
+    fn should_skip_smaller_length() {
+        assert_eq!(
+            align_bytes(&[1, 2, 3, 4, 5, 6, 7, 8], 6),
+            vec![1, 2, 3, 4, 5, 6, 7, 8]
+        );
+    }
+
+    #[test]
+    fn should_align_to_even() {
+        assert_eq!(
+            to_even(&[1, 2, 3, 4, 5, 6, 7]),
+            vec![1, 2, 3, 4, 5, 6, 7, 8]
+        );
+    }
+
+    #[test]
+    fn should_skip_already_even() {
+        assert_eq!(
+            to_even(&[1, 2, 3, 4, 5, 6, 7, 8]),
             vec![1, 2, 3, 4, 5, 6, 7, 8]
         );
     }

--- a/emerald-core/src/util/mod.rs
+++ b/emerald-core/src/util/mod.rs
@@ -99,15 +99,20 @@ pub fn align_bytes(data: &[u8], len: usize) -> Vec<u8> {
     v
 }
 
-/// Padding high bytes with `O` to get even length
+/// Padding hex string with `O` to get even length
 ///
 /// # Arguments
 ///
 /// * `data` - data to be aligned
 ///
-pub fn to_even(data: &[u8]) -> Vec<u8> {
-    let len = data.len();
-    align_bytes(data, len + len % 2)
+pub fn to_even_str(data: &str) -> String {
+    if data.len() % 2 == 0 {
+        return String::from(data);
+    }
+
+    let mut v = String::from("0");
+    v.push_str(data);
+    v
 }
 
 /// Trim all high zero bytes
@@ -308,19 +313,13 @@ mod tests {
     }
 
     #[test]
-    fn should_align_to_even() {
-        assert_eq!(
-            to_even(&[1, 2, 3, 4, 5, 6, 7]),
-            vec![1, 2, 3, 4, 5, 6, 7, 8]
-        );
+    fn should_align_to_even_str() {
+        assert_eq!(to_even_str("100"), String::from("0100"));
     }
 
     #[test]
-    fn should_skip_already_even() {
-        assert_eq!(
-            to_even(&[1, 2, 3, 4, 5, 6, 7, 8]),
-            vec![1, 2, 3, 4, 5, 6, 7, 8]
-        );
+    fn should_skip_already_even_str() {
+        assert_eq!(to_even_str("100012"), String::from("100012"));
     }
 
     #[test]

--- a/emerald-core/tests/keystore_test.rs
+++ b/emerald-core/tests/keystore_test.rs
@@ -94,6 +94,7 @@ fn should_decode_keyfile_without_address() {
 
     let exp = KeyFile {
         name: Some("".to_string()),
+        visible: None,
         description: None,
         address: Address::from_str("0x4c4cfc6470a1dc26916585ef03dfec42deb936ff").unwrap(),
         uuid: Uuid::from_str("37e0d14f-7269-7ca0-4419-d7b13abfeea9").unwrap(),
@@ -137,6 +138,7 @@ fn should_decode_keyfile_without_address() {
     assert_eq!(key.cipher_text, exp.cipher_text);
     assert_eq!(key.cipher_iv, exp.cipher_iv);
     assert_eq!(key.keccak256_mac, exp.keccak256_mac);
+    assert_eq!(key.visible, exp.visible);
 }
 
 #[test]
@@ -148,6 +150,7 @@ fn should_decode_keyfile_with_address() {
     let exp = KeyFile {
         name: None,
         description: None,
+        visible: None,
         address: Address::from_str("0x0047201aed0b69875b24b614dda0270bcd9f11cc").unwrap(),
         uuid: Uuid::from_str("f7ab2bfa-e336-4f45-a31f-beb3dd0689f3").unwrap(),
         dk_length: 32,
@@ -191,6 +194,7 @@ fn should_decode_keyfile_with_address() {
     assert_eq!(key.cipher_text, exp.cipher_text);
     assert_eq!(key.cipher_iv, exp.cipher_iv);
     assert_eq!(key.keccak256_mac, exp.keccak256_mac);
+    assert_eq!(key.visible, exp.visible);
 }
 
 #[test]
@@ -217,7 +221,7 @@ fn should_search_by_address() {
         .parse::<Address>()
         .unwrap();
 
-    let kf = KeyFile::search_by_address(&addr, &keystore_path()).unwrap();
+    let (_, kf) = KeyFile::search_by_address(&addr, &keystore_path()).unwrap();
 
     assert_eq!(
         kf.uuid,

--- a/emerald-core/tests/keystore_test.rs
+++ b/emerald-core/tests/keystore_test.rs
@@ -95,7 +95,6 @@ fn should_decode_keyfile_without_address() {
     let exp = KeyFile {
         visible: None,
         name: Some("".to_string()),
-        visible: None,
         description: None,
         address: Address::from_str("0x4c4cfc6470a1dc26916585ef03dfec42deb936ff").unwrap(),
         uuid: Uuid::from_str("37e0d14f-7269-7ca0-4419-d7b13abfeea9").unwrap(),
@@ -152,7 +151,6 @@ fn should_decode_keyfile_with_address() {
         visible: None,
         name: None,
         description: None,
-        visible: None,
         address: Address::from_str("0x0047201aed0b69875b24b614dda0270bcd9f11cc").unwrap(),
         uuid: Uuid::from_str("f7ab2bfa-e336-4f45-a31f-beb3dd0689f3").unwrap(),
         dk_length: 32,


### PR DESCRIPTION
Added info for rpc errors.
Added handling for odd `nonce` hex string values
Related to #146 