### PR TITLE
Missed functionality for chain-id cli argument

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,11 +52,11 @@ environment:
   # Nightly 64-bit MSVC
     - channel: nightly
       target: x86_64-pc-windows-msvc
-      cargoflags: --all --features "dev"
+      cargoflags: --features "dev"
   # Nightly 32-bit MSVC
     - channel: nightly
       target: i686-pc-windows-msvc
-      cargoflags: --all --features "dev"
+      cargoflags: --features "dev"
 
 ### GNU Toolchains ###
 
@@ -75,11 +75,11 @@ environment:
   # Nightly 64-bit GNU
     - channel: nightly
       target: x86_64-pc-windows-gnu
-      cargoflags: --all  --features "dev"
+      cargoflags:  --features "dev"
   # Nightly 32-bit GNU
     - channel: nightly
       target: i686-pc-windows-gnu
-      cargoflags: --all --features "dev"
+      cargoflags:  --features "dev"
 
 ### Allowed failures ###
 

--- a/emerald-cli/src/main.rs
+++ b/emerald-cli/src/main.rs
@@ -65,8 +65,8 @@ fn main() {
     }
 
     log_builder.format(|record: &LogRecord| {
-         format!("[{}]\t{}", record.level(), record.args())
-     });
+        format!("[{}]\t{}", record.level(), record.args())
+    });
 
     log_builder.init().expect("Expect to initialize logger");
     if args.flag_version {

--- a/emerald-cli/src/main.rs
+++ b/emerald-cli/src/main.rs
@@ -18,8 +18,9 @@ extern crate regex;
 
 use docopt::Docopt;
 use emerald::keystore::KdfDepthLevel;
+use emerald::to_chain_id;
 use env_logger::LogBuilder;
-use log::LogLevel;
+use log::{LogLevel, LogRecord};
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -37,6 +38,8 @@ struct Args {
     flag_port: String,
     flag_base_path: String,
     flag_security_level: String,
+    flag_chain: String,
+    flag_chain_id: u8,
     cmd_server: bool,
 }
 
@@ -61,6 +64,10 @@ fn main() {
         log_builder.parse(&env::var("RUST_LOG").unwrap());
     }
 
+    log_builder.format(|record: &LogRecord| {
+         format!("[{}]\t{}", record.level(), record.args())
+     });
+
     log_builder.init().expect("Expect to initialize logger");
     if args.flag_version {
         println!("v{}", emerald::version());
@@ -69,6 +76,16 @@ fn main() {
 
     if log_enabled!(LogLevel::Info) {
         info!("Starting Emerald Connector - v{}", emerald::version());
+    }
+
+    let chain = match args.flag_chain.parse::<String>() {
+        Ok(c) => c,
+        Err(_) => "mainnet".to_string(),
+    };
+
+    if to_chain_id(&chain) != args.flag_chain_id {
+        error!("Inconsistent `--chain-id` and `--chain` arguments!");
+        exit(1);
     }
 
     let sec_level: &str = &args.flag_security_level.parse::<String>().expect(
@@ -99,7 +116,8 @@ fn main() {
         } else {
             None
         };
-        emerald::rpc::start(&addr, base_path, Some(sec_level));
+
+        emerald::rpc::start(&addr, args.flag_chain_id, base_path, Some(sec_level));
     }
 
 }

--- a/emerald-core/src/util/mod.rs
+++ b/emerald-core/src/util/mod.rs
@@ -36,6 +36,32 @@ impl ToHex for u64 {
     }
 }
 
+/// Get chain name by chain id
+///
+/// # Arguments:
+/// * `id` - target chain id
+///
+pub fn to_chain_name(id: u8) -> String {
+    match id {
+        61 => "mainnet".to_string(),
+        62 => "testnet".to_string(),
+        _ => "mainnet".to_string(),
+    }
+}
+
+/// Get chain id by chain name
+///
+/// # Arguments:
+/// * `name` - target chain name
+///
+pub fn to_chain_id(name: &str) -> u8 {
+    match name {
+        "mainnet" => 61,
+        "testnet" => 62,
+        _ => 61,
+    }
+}
+
 /// Convert byte array into `u64`
 ///
 /// # Arguments


### PR DESCRIPTION
Added functionality for `--chain-id` & `--chain` cli arguments handling.
Transaction singning now uses specified chain,
Related to #150 