### PR TITLE
Appveyor is very slow and build a lot of useless variants

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,55 +49,6 @@ environment:
   # Beta 32-bit MSVC
     - channel: beta
       target: i686-pc-windows-msvc
-  # Nightly 64-bit MSVC
-    - channel: nightly
-      target: x86_64-pc-windows-msvc
-      cargoflags: --features "dev"
-  # Nightly 32-bit MSVC
-    - channel: nightly
-      target: i686-pc-windows-msvc
-      cargoflags: --features "dev"
-
-### GNU Toolchains ###
-
-  # Stable 64-bit GNU
-    - channel: stable
-      target: x86_64-pc-windows-gnu
-  # Stable 32-bit GNU
-    - channel: stable
-      target: i686-pc-windows-gnu
-  # Beta 64-bit GNU
-    - channel: beta
-      target: x86_64-pc-windows-gnu
-  # Beta 32-bit GNU
-    - channel: beta
-      target: i686-pc-windows-gnu
-  # Nightly 64-bit GNU
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
-      cargoflags:  --features "dev"
-  # Nightly 32-bit GNU
-    - channel: nightly
-      target: i686-pc-windows-gnu
-      cargoflags:  --features "dev"
-
-### Allowed failures ###
-
-# See Appveyor documentation for specific details. In short, place any channel or targets you wish
-# to allow build failures on (usually nightly at least is a wise choice). This will prevent a build
-# or test failure in the matching channels/targets from failing the entire build.
-matrix:
-  allow_failures:
-    - channel: nightly
-
-# If you only care about stable channel build failures, uncomment the following line:
-    #- channel: beta
-
-### GNU Toolchains ###
-  # 64-bit GNU
-    - target: x86_64-pc-windows-gnu
-  # 32-bit GNU
-    - target: i686-pc-windows-gnu
 
 # Only build against the branches that will have pull requests built against them (master).
 # Otherwise creating feature branches on this repository and a pull requests against them will


### PR DESCRIPTION
Cut off GNU Toolchain and for MSCV nightly channel.