### PR TITLE
Chain name and id can be inconsistent in rpc call params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 - cargo build --all --verbose --release
 deploy:
   provider: releases
+  skip_cleanup: true
   api_key:
     secure: qXqFCva/yJfwdJzLUazv3AUqvnbUWWEvCOoZHMkByK7/OP1yGdB/q7R24IRAf5SvfEk9TR8a81i+tiy/3iLfgrrBPLc077cLB4q6q1O1yBIrRTg61ggUDyiKaZDZqHtuvI2ocTnFM5jXTuEXVVGt0HA1IO3ezogmcVi9UrQp5rDDCWqPcNviTVweTICLb9PAWKmhbGrGmR3BVuNjmBCDJr25qnW6wors93xfCrpePepnl92gvPrp30WmQ2E+bgV+Hoeu9gJjCIjRU8bTmDWEdkBa3Qe8xIMU+SAw7CBUWRALh5q1HX0M7RYpg3zOEdVdWZ+OwDTO0mc40UdaV5rkx029ird4mC96bkHHemYITJJrDrwjoni9wSbnhZaNefZeKf8pAGLUO/+NwtcYbj8ogYdnsweAMRiZUvA15/tzk6kMQqBILjL605YayPWt9XvdU06gLjWtEd8qlOqt+xBPat3dKw15Xkb8XPM8bc6+YBHDvJC9tF4vozOsj9Sh4b/RV9+tB0xrjniY/ZRMtGe6JJO+7+7naszekz+F9lZJocmAhbX7XUsgyvjhmVn/1+IKnJQ/iqIn7FNQa+7y9ONmQxke4aibKdM3vTicgwwPD4IY2i9MGLCBDUFIiu70k8pJ2Gy4xa8E0LupcHui4uysG2ukqJhPU/4rN9v7HZznE3Y=
   file: target/release/emerald


### PR DESCRIPTION
RPC call can receive inconsistent chain parameters (name & id). 
Added check to handle error