### PR TITLE
Rpc call `emerald_listAccounts` doesn't use chain name for listing 

### DIFF
--- a/emerald-core/src/keystore/serialize/mod.rs
+++ b/emerald-core/src/keystore/serialize/mod.rs
@@ -172,7 +172,6 @@ pub fn list_accounts<P: AsRef<Path>>(
             continue;
         }
         let entry = e.unwrap();
-
         let mut content = String::new();
         if let Ok(mut keyfile) = File::open(entry.path()) {
             if keyfile.read_to_string(&mut content).is_err() {

--- a/emerald-core/src/rpc/error.rs
+++ b/emerald-core/src/rpc/error.rs
@@ -7,7 +7,7 @@ use keystore;
 use reqwest;
 use rustc_serialize;
 use serde_json;
-use std::{error, fmt};
+use std::{error, fmt, io};
 
 /// JSON RPC errors
 #[derive(Debug)]
@@ -35,6 +35,12 @@ impl From<rustc_serialize::json::DecoderError> for Error {
 impl From<keystore::Error> for Error {
     fn from(_err: keystore::Error) -> Self {
         Error::InvalidDataFormat("keystore error".to_string())
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::InvalidDataFormat(e.to_string())
     }
 }
 

--- a/emerald-core/src/rpc/mod.rs
+++ b/emerald-core/src/rpc/mod.rs
@@ -53,8 +53,8 @@ pub fn start(
     let sec_level = sec_level.unwrap_or_default();
 
     let storage = match base_path {
-        Some(p) => Storages::new(p),
-        None => Storages::default(),
+        Some(p) => Arc::new(Storages::new(p)),
+        None => Arc::new(Storages::default()),
     };
 
     if storage.init().is_err() {
@@ -82,10 +82,10 @@ pub fn start(
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_listAccounts", move |p: Params| {
-            wrapper(serves::list_accounts(parse(p)?, &keystore_path))
+            wrapper(serves::list_accounts(parse(p)?, &storage))
         });
     }
 

--- a/emerald-core/src/rpc/serves.rs
+++ b/emerald-core/src/rpc/serves.rs
@@ -1,4 +1,5 @@
 use super::Error;
+use super::Storages;
 use super::serialize::RPCTransaction;
 
 use core::Address;
@@ -85,10 +86,11 @@ pub struct ListAccountsAdditional {
 
 pub fn list_accounts(
     params: Either<(), (ListAccountsAdditional,)>,
-    keystore_path: &PathBuf,
+    storage: &Storages,
 ) -> Result<Vec<ListAccountAccount>, Error> {
     let (additional,) = params.into_right();
-    let res = keystore::list_accounts(keystore_path, additional.show_hidden)?
+    let keystore_path = storage.get_keystore_path(&additional.chain)?;
+    let res = keystore::list_accounts(&keystore_path, additional.show_hidden)?
         .iter()
         .map(|&(ref name, ref address)| {
             ListAccountAccount {

--- a/emerald-core/src/rpc/serves.rs
+++ b/emerald-core/src/rpc/serves.rs
@@ -100,8 +100,9 @@ pub fn list_accounts(
         })
         .collect();
     debug!(
-        "Accounts listed with `show_hidden`: {}\n\t{:?}",
+        "Accounts listed with `show_hidden`: {} for path: {:?}\n\t{:?}",
         additional.show_hidden,
+        keystore_path,
         res
     );
 

--- a/emerald-core/src/storage.rs
+++ b/emerald-core/src/storage.rs
@@ -67,10 +67,11 @@ impl Storages {
     pub fn get_keystore_path(&self, chain_name: &str) -> Result<PathBuf, Error> {
         for entry in fs::read_dir(&self.base_dir)? {
             let entry = entry?;
-            let path = entry.path();
+            let mut path = entry.path();
 
             if path.is_dir() && path.file_name().is_some() {
                 if path.file_name().unwrap() == chain_name {
+                    path.push("keystore");
                     return Ok(path);
                 }
             }

--- a/emerald-core/src/storage.rs
+++ b/emerald-core/src/storage.rs
@@ -2,7 +2,7 @@
 
 use log::LogLevel;
 use std::{env, fs};
-use std::io::Error;
+use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
 /// Base dir for internal data, all chain-related should be store in subdirectories
@@ -61,6 +61,25 @@ impl Storages {
             fs::create_dir(self.base_dir.as_path())?
         }
         Ok(())
+    }
+
+    /// Get keystore storage by chain name
+    pub fn get_keystore_path(&self, chain_name: &str) -> Result<PathBuf, Error> {
+        for entry in fs::read_dir(&self.base_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_dir() && path.file_name().is_some() {
+                if path.file_name().unwrap() == chain_name {
+                    return Ok(path);
+                }
+            }
+        }
+
+        Err(Error::new(
+            ErrorKind::InvalidInput,
+            "No keystorage for specified chain name",
+        ))
     }
 }
 


### PR DESCRIPTION
Fixed listing functionality for rpc call to use chain name
Related to #185