### PR TITLE
Rpc calls doesn't used optional `chain` parameters 

### DIFF
--- a/emerald-core/src/rpc/mod.rs
+++ b/emerald-core/src/rpc/mod.rs
@@ -83,77 +83,87 @@ pub fn start(
 
     {
         let storage = storage.clone();
+        let default_keystore = keystore_path.clone();
 
         io.add_method("emerald_listAccounts", move |p: Params| {
-            wrapper(serves::list_accounts(parse(p)?, &storage))
+            wrapper(serves::list_accounts(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_hideAccount", move |p: Params| {
-            wrapper(serves::hide_account(parse(p)?, &keystore_path))
+            wrapper(serves::hide_account(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_unhideAccount", move |p: Params| {
-            wrapper(serves::unhide_account(parse(p)?, &keystore_path))
+            wrapper(serves::unhide_account(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_shakeAccount", move |p: Params| {
-            wrapper(serves::shake_account(parse(p)?, &keystore_path))
+            wrapper(serves::shake_account(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_updateAccount", move |p: Params| {
-            wrapper(serves::update_account(parse(p)?, &keystore_path))
+            wrapper(serves::update_account(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_importAccount", move |p: Params| {
-            wrapper(serves::import_account(parse(p)?, &keystore_path))
+            wrapper(serves::import_account(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_exportAccount", move |p: Params| {
-            wrapper(serves::export_account(parse(p)?, &keystore_path))
+            wrapper(serves::export_account(parse(p)?, &default_keystore, &storage))
         });
     }
 
     {
         let sec = sec_level;
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
 
         io.add_method("emerald_newAccount", move |p: Params| {
-            wrapper(serves::new_account(parse(p)?, &sec, &keystore_path))
+            wrapper(serves::new_account(parse(p)?, &sec, &default_keystore, &storage))
         });
     }
 
     {
-        let keystore_path = keystore_path.clone();
+        let default_keystore = keystore_path.clone();
+        let storage = storage.clone();
         let chain_id = to_chain_id(chain_name).unwrap();
         io.add_method("emerald_signTransaction", move |p: Params| {
             wrapper(serves::sign_transaction(
                 parse(p)?,
-                &keystore_path,
+                &default_keystore,
                 chain_id,
+                &storage
             ))
         });
     }

--- a/emerald-core/src/rpc/mod.rs
+++ b/emerald-core/src/rpc/mod.rs
@@ -86,7 +86,11 @@ pub fn start(
         let default_keystore = keystore_path.clone();
 
         io.add_method("emerald_listAccounts", move |p: Params| {
-            wrapper(serves::list_accounts(parse(p)?, &default_keystore, &storage))
+            wrapper(serves::list_accounts(
+                parse(p)?,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -104,7 +108,11 @@ pub fn start(
         let storage = storage.clone();
 
         io.add_method("emerald_unhideAccount", move |p: Params| {
-            wrapper(serves::unhide_account(parse(p)?, &default_keystore, &storage))
+            wrapper(serves::unhide_account(
+                parse(p)?,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -113,7 +121,11 @@ pub fn start(
         let storage = storage.clone();
 
         io.add_method("emerald_shakeAccount", move |p: Params| {
-            wrapper(serves::shake_account(parse(p)?, &default_keystore, &storage))
+            wrapper(serves::shake_account(
+                parse(p)?,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -122,7 +134,11 @@ pub fn start(
         let storage = storage.clone();
 
         io.add_method("emerald_updateAccount", move |p: Params| {
-            wrapper(serves::update_account(parse(p)?, &default_keystore, &storage))
+            wrapper(serves::update_account(
+                parse(p)?,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -131,7 +147,11 @@ pub fn start(
         let storage = storage.clone();
 
         io.add_method("emerald_importAccount", move |p: Params| {
-            wrapper(serves::import_account(parse(p)?, &default_keystore, &storage))
+            wrapper(serves::import_account(
+                parse(p)?,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -140,7 +160,11 @@ pub fn start(
         let storage = storage.clone();
 
         io.add_method("emerald_exportAccount", move |p: Params| {
-            wrapper(serves::export_account(parse(p)?, &default_keystore, &storage))
+            wrapper(serves::export_account(
+                parse(p)?,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -150,7 +174,12 @@ pub fn start(
         let storage = storage.clone();
 
         io.add_method("emerald_newAccount", move |p: Params| {
-            wrapper(serves::new_account(parse(p)?, &sec, &default_keystore, &storage))
+            wrapper(serves::new_account(
+                parse(p)?,
+                &sec,
+                &default_keystore,
+                &storage,
+            ))
         });
     }
 
@@ -163,7 +192,7 @@ pub fn start(
                 parse(p)?,
                 &default_keystore,
                 chain_id,
-                &storage
+                &storage,
             ))
         });
     }

--- a/emerald-core/src/rpc/serves.rs
+++ b/emerald-core/src/rpc/serves.rs
@@ -156,9 +156,9 @@ pub struct UnhideAccountAccount {
 pub fn unhide_account(
     params: Either<(UnhideAccountAccount,), (UnhideAccountAccount, CommonAdditional)>,
     default_keystore: &PathBuf,
-    storage: &Storages
+    storage: &Storages,
 ) -> Result<bool, Error> {
-    let (account, additional) =  params.into_full();
+    let (account, additional) = params.into_full();
     let path = get_path!(additional.chain, default_keystore.clone(), storage);
 
     let addr = Address::from_str(&account.address)?;
@@ -178,7 +178,7 @@ pub struct ShakeAccountAccount {
 pub fn shake_account(
     params: Either<(ShakeAccountAccount,), (ShakeAccountAccount, CommonAdditional)>,
     default_keystore: &PathBuf,
-    storage: &Storages
+    storage: &Storages,
 ) -> Result<bool, Error> {
     use keystore::os_random;
 
@@ -214,7 +214,7 @@ pub struct UpdateAccountAccount {
 pub fn update_account(
     params: Either<(UpdateAccountAccount,), (UpdateAccountAccount, CommonAdditional)>,
     default_keystore: &PathBuf,
-    storage: &Storages
+    storage: &Storages,
 ) -> Result<bool, Error> {
     let (account, additional) = params.into_full();
     let path = get_path!(additional.chain, default_keystore.clone(), storage);
@@ -263,9 +263,9 @@ pub struct ExportAccountAccount {
 pub fn export_account(
     params: Either<(ExportAccountAccount,), (ExportAccountAccount, CommonAdditional)>,
     default_keystore: &PathBuf,
-    storage: &Storages
+    storage: &Storages,
 ) -> Result<Value, Error> {
-    let (account, additional) =  params.into_full();
+    let (account, additional) = params.into_full();
     let path = get_path!(additional.chain, default_keystore.clone(), storage);
     let addr = Address::from_str(&account.address)?;
 
@@ -290,7 +290,7 @@ pub fn new_account(
     params: Either<(NewAccountAccount,), (NewAccountAccount, CommonAdditional)>,
     sec: &KdfDepthLevel,
     default_keystore: &PathBuf,
-    storage: &Storages
+    storage: &Storages,
 ) -> Result<String, Error> {
     let (account, additional) = params.into_full();
     let path = get_path!(additional.chain, default_keystore.clone(), storage);
@@ -332,7 +332,7 @@ pub fn sign_transaction(
     params: Either<(SignTransactionTransaction,), (SignTransactionTransaction, CommonAdditional)>,
     default_keystore: &PathBuf,
     default_chain_id: u8,
-    storage: &Storages
+    storage: &Storages,
 ) -> Result<Params, Error> {
     let (transaction, additional) = params.into_full();
     let path = get_path!(additional.chain, default_keystore.clone(), storage);


### PR DESCRIPTION
Rpc calls doesn't supported usage of optional parameters for chain selection. 
Added functionality for handling chain args in all rpc calls
Related to #185 #186 