### PR TITLE
RPC call for `update`, `shake` was invalid.

### DIFF
--- a/emerald-core/src/core/transaction.rs
+++ b/emerald-core/src/core/transaction.rs
@@ -36,6 +36,7 @@ impl Transaction {
     pub fn raw_from_sig(&self, chain: u8, mut sig: Signature) -> Vec<u8> {
         let mut rlp = self.to_rlp_raw();
 
+        println!(">> DEBUG signature: {:?}", sig);
         // [Simple replay attack protection](https://github.com/ethereum/eips/issues/155)
         sig.v += chain * 2 + 35 - 27;
 
@@ -43,15 +44,18 @@ impl Transaction {
         rlp.push(&sig.r[..]);
         rlp.push(&sig.s[..]);
 
-        let mut vec = Vec::new();
-        rlp.write_rlp(&mut vec);
+        let mut buf = Vec::new();
+        rlp.write_rlp(&mut buf);
 
-        vec
+        buf
     }
 
     /// RLP packed transaction
     pub fn to_rlp(&self) -> Vec<u8> {
-        self.to_rlp_raw().into()
+        let mut buf = Vec::new();
+        self.to_rlp_raw().write_rlp(&mut buf);
+
+        buf
     }
 
     fn to_rlp_raw(&self) -> RLPList {
@@ -124,7 +128,9 @@ mod tests {
             "c85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
         ));
 
-        assert_eq!(tx.to_signed_raw(pk, 61 /*MAINNET_ID*/).unwrap().to_hex(),
+        let hex = tx.to_signed_raw(pk, 61 /*MAINNET_ID*/).unwrap().to_hex();
+        println!("{:?}", &hex);
+        assert_eq!(hex,
                    "f86d\
                    80\
                    8504e3b29200\
@@ -133,8 +139,10 @@ mod tests {
                    880de0b6b3a7640000\
                    80\
                    819e\
-                   a0b17da8416f42d62192b07ff855f4a8e8e9ee1a2e920e3c407fd9a3bd5e388daa\
-                   a0547981b617c88587bfcd924437f6134b0b75f4484042db0750a2b1c0ccccc597");
+                   a0\
+                   b1\
+                   7da8416f42d62192b07ff855f4a8e8e9ee1a2e920e3c407fd9a3bd5e388daaa0\
+                   547981b617c88587bfcd924437f6134b0b75f4484042db0750a2b1c0ccccc597");
     }
 
     #[test]

--- a/emerald-core/src/hdwallet/mod.rs
+++ b/emerald-core/src/hdwallet/mod.rs
@@ -324,7 +324,7 @@ mod tests {
         let sign = manager.sign_transaction(&fd, &rlp, None);
 
         assert!(sign.is_ok());
-        debug!("Signature: {:?}", &sign.unwrap());
+        println!("Signature: {:?}", &sign.unwrap());
     }
 
     #[test]

--- a/emerald-core/src/keystore/serialize/mod.rs
+++ b/emerald-core/src/keystore/serialize/mod.rs
@@ -143,10 +143,16 @@ impl KeyFile {
     /// * `dir` - path to destination directory
     /// * `addr` - a public address (optional)
     ///
-    pub fn flush<P: AsRef<Path>>(&self, dir: P) -> Result<(), Error> {
-        let path = dir.as_ref().join(
-            &generate_filename(&self.uuid.to_string()),
-        );
+    pub fn flush<P: AsRef<Path>>(&self, dir: P, filename: Option<&str>) -> Result<(), Error> {
+        let tmp;
+        let name = match filename {
+            Some(n) => n,
+            None => {
+                tmp = generate_filename(&self.uuid.to_string());
+                &tmp
+            }
+        };
+        let path = dir.as_ref().join(name);
 
         Ok(write(self, path)?)
     }

--- a/emerald-core/src/rpc/error.rs
+++ b/emerald-core/src/rpc/error.rs
@@ -21,20 +21,20 @@ pub enum Error {
 }
 
 impl From<rustc_serialize::json::EncoderError> for Error {
-    fn from(_err: rustc_serialize::json::EncoderError) -> Self {
-        Error::InvalidDataFormat("encoder error".to_string())
+    fn from(err: rustc_serialize::json::EncoderError) -> Self {
+        Error::InvalidDataFormat(format!("decoder: {}", err.to_string()))
     }
 }
 
 impl From<rustc_serialize::json::DecoderError> for Error {
-    fn from(_err: rustc_serialize::json::DecoderError) -> Self {
-        Error::InvalidDataFormat("decoder error".to_string())
+    fn from(err: rustc_serialize::json::DecoderError) -> Self {
+        Error::InvalidDataFormat(format!("decoder: {}", err.to_string()))
     }
 }
 
 impl From<keystore::Error> for Error {
-    fn from(_err: keystore::Error) -> Self {
-        Error::InvalidDataFormat("keystore error".to_string())
+    fn from(err: keystore::Error) -> Self {
+        Error::InvalidDataFormat(format!("keystore: {}", err.to_string()))
     }
 }
 

--- a/emerald-core/tests/keystore_test.rs
+++ b/emerald-core/tests/keystore_test.rs
@@ -282,7 +282,7 @@ fn should_use_security_level() {
 fn should_flush_to_file() {
     let kf = KeyFile::new("1234567890", &KdfDepthLevel::Normal, None, None).unwrap();
 
-    assert!(kf.flush(temp_dir().as_path()).is_ok());
+    assert!(kf.flush(temp_dir().as_path(), None).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Fixed duplication problem for `update` and `shake` call,
`Salt` used for KeyFile was 0 array by default, fixed for random generated one.
Related to #188