### PR TITLE
Windows uses low values for scrypt, due to a poor perfomance

### DIFF
--- a/emerald-cli/usage.txt
+++ b/emerald-cli/usage.txt
@@ -16,5 +16,5 @@ Options:
                                                   + Mac OS X: ~/Library/Emerald
                                                   + Linux: ~/.emerald
                                                   + Windows: %USERDIR%\.emerald
-      --security-level <normal|high|ultra>    Level of security for cryptographic operations [default: normal]
+      --security-level <normal|high|ultra>    Level of security for cryptographic operations [default: ultra]
   -c, --chain <mainnet|testnet>               Chain name [default: mainnet]

--- a/emerald-core/tests/keystore_test.rs
+++ b/emerald-core/tests/keystore_test.rs
@@ -260,6 +260,8 @@ fn should_decode_hd_wallet_keyfile() {
 }
 
 #[test]
+//TODO:1 remove condition after fix for `scrypt` on Windows
+#[cfg(not(target_os = "windows"))]
 fn should_use_security_level() {
     let sec = KdfDepthLevel::Normal;
     let kf = KeyFile::new("1234567890", &sec, None, None).unwrap();


### PR DESCRIPTION
Usage of `scrypt` C binding prohibited on Windows due to usage of mmap sys call inside scrypt
 Windows version of vault swapped to `pbkdf2` usage for creation of new account, it will still support import of account with `scrypt`