### PR TITLE
Passphrase argument can't be skiped while signing with HD wallet

### DIFF
--- a/emerald-core/src/hdwallet/mod.rs
+++ b/emerald-core/src/hdwallet/mod.rs
@@ -226,11 +226,6 @@ impl WManager {
             _ => tr.split_at(CHUNK_SIZE - hd_path.len()),
         };
 
-        println!(
-            "Sign transaction with HD Wallet from address: {}",
-            self.get_address(fd, Some(hd_path.clone()))?
-        );
-
         let init_apdu = ApduBuilder::new(SIGN_ETH_TRANSACTION)
             .with_p1(0x00)
             .with_data(&hd_path)

--- a/emerald-core/src/rpc/serialize.rs
+++ b/emerald-core/src/rpc/serialize.rs
@@ -41,13 +41,6 @@ impl RPCTransaction {
 }
 
 impl Transaction {
-    //    /// Sign transaction and return as raw data
-    //    pub fn to_raw_params(&self, pk: PrivateKey, chain: u8) -> Params {
-    //        self.to_signed_raw(pk, chain)
-    //            .map(|v| format!("0x{}", v.to_hex()))
-    //            .map(|s| Params::Array(vec![JsonRpcValue::String(s)]))
-    //            .expect("Expect to sign a transaction")
-    //    }
     /// Signed transaction into raw data
     pub fn to_raw_params(signed_rlp: Vec<u8>) -> Params {
         let str = format!("0x{}", signed_rlp.to_hex());

--- a/emerald-core/src/rpc/serves.rs
+++ b/emerald-core/src/rpc/serves.rs
@@ -316,7 +316,8 @@ pub struct SignTransactionTransaction {
     #[serde(default)]
     pub data: String,
     pub nonce: String,
-    pub passphrase: String,
+    #[serde(default)]
+    pub passphrase: Option<String>,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -361,7 +362,14 @@ pub fn sign_transaction(
                 Ok(tr) => {
                     match kf.crypto {
                         CryptoType::Core(_) => {
-                            if let Ok(pk) = kf.decrypt_key(&transaction.passphrase) {
+                            if transaction.passphrase.is_none() {
+                                return Err(
+                                    Error::InvalidDataFormat("Missing passphrase".to_string()),
+                                );
+                            }
+                            let pass = transaction.passphrase.unwrap();
+
+                            if let Ok(pk) = kf.decrypt_key(&pass) {
                                 let raw = tr.to_signed_raw(pk, chain_id).expect(
                                     "Expect to sign a \
                                      transaction",


### PR DESCRIPTION
Passphrase ignored while sign with HD wallet
Related to #216 