### PR TITLE
Missd flag for marking hidden files for json-rpc result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald-rs"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Dmitry Ulanov <dulanov@gmail.com>", "Constantine Kryvomaz <kostiyantynk@gmail.com>", "Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "Ethereum Classic secure account management core libary"
 homepage = "http://etcdevteam.com"

--- a/src/rpc/serialize.rs
+++ b/src/rpc/serialize.rs
@@ -21,13 +21,15 @@ pub struct RPCTransaction {
 
 impl RPCTransaction {
     pub fn try_into(self) -> Result<Transaction, Error> {
-        let gp_str = trim_hex(self.gas_price.as_str());
-        let v_str = trim_hex(self.value.as_str());
+        let gp_str = to_even_str(trim_hex(self.gas_price.as_str()));
+        let v_str = to_even_str(trim_hex(self.value.as_str()));
+        let gasl_str = to_even_str(trim_hex(self.gas.as_str()));
 
-        let gas_limit = Vec::from_hex(trim_hex(self.gas.as_str()))?;
+        let gas_limit = Vec::from_hex(gasl_str)?;
         let gas_price = Vec::from_hex(gp_str)?;
         let value = Vec::from_hex(v_str)?;
         let nonce = Vec::from_hex(to_even_str(trim_hex(self.nonce.as_str())))?;
+        let data = to_even_str(trim_hex(self.data.as_str()));
 
         Ok(Transaction {
             nonce: to_u64(&nonce),
@@ -35,7 +37,7 @@ impl RPCTransaction {
             gas_limit: to_u64(&gas_limit),
             to: self.to.as_str().parse::<Address>().ok(),
             value: to_arr(&align_bytes(&value, 32)),
-            data: Vec::from_hex(trim_hex(self.data.as_str()))?,
+            data: Vec::from_hex(data)?,
         })
     }
 }

--- a/src/rpc/serves.rs
+++ b/src/rpc/serves.rs
@@ -75,6 +75,7 @@ pub struct ListAccountAccount {
     address: String,
     description: String,
     hardware: bool,
+    is_hidden: bool,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -107,6 +108,7 @@ where
                 address: info.address.clone(),
                 description: info.description.clone(),
                 hardware: info.is_hardware,
+                is_hidden: info.is_hidden,
             }
         })
         .collect();

--- a/src/storage/keyfile/mod.rs
+++ b/src/storage/keyfile/mod.rs
@@ -35,6 +35,10 @@ pub struct AccountInfo {
     /// shows whether it is normal account or
     /// held by HD wallet
     pub is_hardware: bool,
+
+    /// show if account hidden from 'normal' listing
+    /// `normal` - not forcing to show hidden accounts
+    pub is_hidden: bool,
 }
 
 impl From<KeyFile> for AccountInfo {
@@ -48,6 +52,10 @@ impl From<KeyFile> for AccountInfo {
 
         if let Some(desc) = kf.description {
             info.description = desc;
+        };
+
+        if let Some(visible) = kf.visible {
+            info.is_hidden = !visible;
         };
 
         info.is_hardware = match kf.crypto {


### PR DESCRIPTION
emerald_listAccounts should provide additional flag for marking hidden files.
Whenever used `show_hidden` option, this flag should show which account originaly hidden 
Related to #198 