### PR TITLE
OpenAlias support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ reqwest = { version = "0.6", optional = true }
 clippy = {version = "0.0", optional = true}
 chrono = "0.4"
 hidapi = "0.4"
+openalias = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -61,3 +62,4 @@ default = ["http", "emerald-rocksdb"]
 http = ["hyper", "reqwest"]
 dev = ["clippy"]
 fs-storage = []
+openalias-support = ["openalias"]

--- a/shell.nix
+++ b/shell.nix
@@ -30,6 +30,6 @@ with pkgs;
 stdenv.mkDerivation {
   name = "emerald-env";
   buildInputs = [
-    rustc cargo openssl pkgconfig
+    rustc cargo openssl pkgconfig libusb
   ];
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ extern crate hex;
 extern crate hidapi;
 extern crate emerald_rocksdb as rocksdb;
 
+#[cfg(feature = "openalias-support")]
+extern crate openalias;
+
 mod core;
 pub mod addressbook;
 pub mod keystore;

--- a/src/rpc/serves.rs
+++ b/src/rpc/serves.rs
@@ -362,7 +362,7 @@ pub fn sign_transaction(
     {
         use openalias;
 
-        if !transaction.from.starts_with("0x") {
+        if !transaction.to.starts_with("0x") {
             if let Ok(addresses) = openalias::addresses(&transaction.to) {
                 for address in addresses {
                     if &address.cryptocurrency == "etc" {


### PR DESCRIPTION
This adds openalias (https://openalias.org/) support, hidden behind the `openalias-support` feature gate. This allows associating an address (be it BTC, XMR or ETC) to a domain name, so it is less likely to be hijacked and easier for users to read.

When it's enabled, on signing a transaction, it checks if the to address starts with `0x`, if not, it will try to parse it as an openalias using the DNS TXT record.

An example of ETC's OpenAlias address can be found at `donate.that.world`:

```
$ dig -t txt donate.that.world

;; ANSWER SECTION:
donate.that.world.	97	IN	TXT	"oa1:etc recipient_address=0x001bAec5aDBF44d9d5A50B50D72e92921FCD528D; recipient_name=That World Donations;"
```