### PR TITLE
 Problem: cargo fmt does not work after new rust release 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ notifications:
 before_install:
 - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get -qq update; else brew update; fi
 - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y libusb-1.0-0-dev; else brew install libusb; fi
-- travis_wait cargo install rustfmt-nightly --force  || true
+- travis_wait cargo install rustfmt --force  || true
 
 before_script:
 - export PATH="$PATH":~/.cargo/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
   email:
     on_success: never
 before_install:
-- if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get -qq update; else brew update; fi
+- if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get --force-yes -qq update; else brew update; fi
 - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install -y libusb-1.0-0-dev; else brew install libusb; fi
 - travis_wait cargo install rustfmt --force  || true
 


### PR DESCRIPTION
Solution: install rustfmt instead rustfmt-nightly